### PR TITLE
Fix color names in theme palette

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,8 +6,8 @@ theme:
   name: material
   palette:
     scheme: default
-    primary: gray
-    accent: blue gray
+    primary: grey
+    accent: blue grey
   font:
     text: Merriweather
     code: Fira Mono


### PR DESCRIPTION
## Summary
- correct British spelling for palette colors
- ensure `mkdocs.yml` ends with a newline

## Testing
- `od -c mkdocs.yml | tail -n 2`

------
https://chatgpt.com/codex/tasks/task_e_684459882ecc8325a6911f46d847e906